### PR TITLE
Wip/deb

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
 tooth (2.1.0~alpha-1) unstable; urgency=medium
 
-  * Initial release (Closes: #nnnn)  <nnnn is the bug number of your ITP>
+  * Initial release (Closes: #1)
 
  -- maryjane <maryjane@disroot.org>  Fri, 02 Dec 2022 14:17:49 +0000

--- a/debian/control
+++ b/debian/control
@@ -1,12 +1,12 @@
 Source: tooth
-Section: unknown
+Section: x11
 Priority: optional
 Maintainer: maryjane <maryjane@disroot.org>
 Build-Depends:
  debhelper-compat (= 13),
  appstream-util,
  gettext,
- libglib2.0-dev,
+ libglib2.0-dev (>= 2.30.0),
  libjson-glib-dev,
  libxml2-dev,
  libgee-0.8-dev,
@@ -14,7 +14,7 @@ Build-Depends:
  libgtk-4-dev,
  libadwaita-1-dev,
  libsecret-1-dev,
- valac
+ valac (>= 0.26)
 Standards-Version: 4.5.1
 Homepage: https://github.com/GeopJr/Tooth
 #Vcs-Browser: https://github.com/GeopJr/Tooth

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,25 +1,23 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: tooth
-Upstream-Contact: <preferred name and address to reach the upstream project>
-Source: <url://example.com>
+Upstream-Contact: https://github.com/GeopJr/Tooth/issues
+Source: https://github.com/GeopJr/Tooth
 
 Files: *
-Copyright: <years> <put author's name and email here>
-           <years> <likewise for another author>
-License: <special license>
- <Put the license of the package here indented by 1 space>
- <This follows the format of Description: lines in control file>
- .
- <Including paragraphs>
+Copyright: 2018-2021 Bleak Grey <bleakgrey@gmail.com>
+           2022 Evangelos Paterakis <evan@geopjr.dev>
+License: GPL-3+
 
-# If you want to use GPL v2 or later for the /debian/* files use
-# the following clauses, or change it to suit. Delete these two lines
 Files: debian/*
-Copyright: 2022 João Azevedo <maryjane@disroot.org>
-License: GPL-2+
- This package is free software; you can redistribute it and/or modify
+Copyright: 2018 Bleak Grey <bleakgrey@gmail.com>
+           2018 Federico Ceratto <federico@debian.org>
+           2022 Maryjane <maryjane@disroot.org>
+License: GPL-3.0+
+
+License: GPL-3.0+
+ This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
- the Free Software Foundation; either version 2 of the License, or
+ the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
  .
  This package is distributed in the hope that it will be useful,
@@ -28,16 +26,7 @@ License: GPL-2+
  GNU General Public License for more details.
  .
  You should have received a copy of the GNU General Public License
- along with this program. If not, see <https://www.gnu.org/licenses/>
+ along with this program. If not, see <http://www.gnu.org/licenses/>.
  .
  On Debian systems, the complete text of the GNU General
- Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".
-
-# Please also look if there are files or directories which have a
-# different copyright/license attached and list them here.
-# Please avoid picking licenses with terms that are more restrictive than the
-# packaged work, as it may make Debian's contributions unacceptable upstream.
-#
-# If you need, there are some extra license texts available in two places:
-#   /usr/share/debhelper/dh_make/licenses/
-#   /usr/share/common-licenses/
+ Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".

--- a/debian/rules
+++ b/debian/rules
@@ -1,25 +1,29 @@
 #!/usr/bin/make -f
-# See debhelper(7) (uncomment to enable)
-# output every command that modifies files on the build system.
-#export DH_VERBOSE = 1
+export DH_VERBOSE = 1
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
-
-# see FEATURE AREAS in dpkg-buildflags(1)
-#export DEB_BUILD_MAINT_OPTIONS = hardening=+all
-
-# see ENVIRONMENT in dpkg-buildflags(1)
-# package maintainers to append CFLAGS
-#export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
-# package maintainers to append LDFLAGS
-#export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
-
+include /usr/share/dpkg/default.mk  # provides DEB_VERSION
 
 %:
 	dh $@
 
+override_dh_auto_clean:
+	rm -rf debian/build
 
-# dh_make generated override targets
-# This is example for Cmake (See https://bugs.debian.org/641051 )
-#override_dh_auto_configure:
-#	dh_auto_configure -- \
-#	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
+override_dh_auto_configure:
+	dh_auto_configure --builddirectory=debian/build
+
+override_dh_auto_build:
+	cd debian/build && ninja -v
+
+override_dh_auto_test:
+ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
+	cd debian/build && ninja test
+endif
+
+override_dh_auto_install:
+	cd debian/build && DESTDIR=${CURDIR}/debian/tooth ninja install
+	mv debian/tooth/usr/bin/dev.geopjr.tooth debian/tooth/usr/bin/tooth
+	sed -i 's/^Exec=.*/Exec=tooth/' debian/tooth/usr/share/applications/dev.geopjr.tooth.desktop
+
+


### PR DESCRIPTION
This merge request: 

- Fixes a lintian warning with d/copyright

- Updates d/rules to:
    - Remove comments
    - Enable hardning
    - Enable verbose
    - Import rules from the package Tootle from salsa.debian.org made
    by Federico Ceratto
    - Change binary name from the full app ID: dev.geopjr.tooth to
    just the app name: tooth

- Update d/control to add the proper section and min versions of Valac and libglib

- Update copyright file with names and contacts from the debian contributors and upstream devs, both from tooth and tootle
